### PR TITLE
Fix sort specification for newer versions of MongoDB.

### DIFF
--- a/problems/my_first_query/solution.js
+++ b/problems/my_first_query/solution.js
@@ -9,7 +9,7 @@ MongoClient.connect('mongodb://127.0.0.1:27017/learnmymongodb', function(err, db
     var collection = db
       .collection('test')
       .find({})
-      .sort({'value': '1'})
+      .sort({'value': 1})
       .toArray(function(err, object) {
         if (err) console.warn(err.message);
         console.dir(object);


### PR DESCRIPTION
As of >=2.6 MongoDB does not accept "1" as a valid specification
and throws an error:
Can't canonicalize query: BadValue bad sort specification

See:
http://docs.mongodb.org/manual/release-notes/2.6-compatibility/#sort-specification-values
